### PR TITLE
fix(gatsby-theme-demo): change publishConfig: registry to https://npm…

### DIFF
--- a/packages/gatsby-theme-demo/package.json
+++ b/packages/gatsby-theme-demo/package.json
@@ -28,7 +28,7 @@
   },
   "keywords": [],
   "publishConfig": {
-    "@smerth:registry": "https://npm.pkg.github.com/smerth"
+    "registry": "https://npm.pkg.github.com"
   },
   "gitHead": "481e2cdacf8d123ef8bb1c987d1778986be98045"
 }


### PR DESCRIPTION
change publishConfig to  "registry": "https://npm.pkg.github.com"